### PR TITLE
Export button in export menu, use input names when changing shader

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -193,7 +193,7 @@ def register():
         bpy.utils.register_class(cls)
 
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
-    bpy.types.TOPBAR_MT_file_import.append(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.append(menu_func_export)
 
 
 def unregister():
@@ -201,7 +201,7 @@ def unregister():
         bpy.utils.unregister_class(cls)
 
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
-    bpy.types.TOPBAR_MT_file_import.remove(menu_func_export)
+    bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
 
 
 if __name__ == "__main__":

--- a/import_hsd.py
+++ b/import_hsd.py
@@ -1218,14 +1218,14 @@ active: %.8X' % ((tev.color_op, tev.alpha_op, tev.color_bias, tev.alpha_bias,\
         #links.new(last_alpha, alpha_factor.inputs[0])
         #last_alpha = alpha_factor.outputs[0]
         #
-        links.new(last_alpha, shader.inputs[18])
+        links.new(last_alpha, shader.inputs[21])
 
     #normal
     if last_bump:
         bump = nodes.new('ShaderNodeBump')
         bump.inputs[1].default_value = 1
         links.new(last_bump, bump.inputs[2])
-        links.new(bump.outputs[0], shader.inputs[19])
+        links.new(bump.outputs[0], shader.inputs[22])
 
     #Add Additive or multiplicative alpha blending, since these don't have explicit options in 2.81 anymore
     if (alt_blend_mode == 'ADD'):

--- a/import_hsd.py
+++ b/import_hsd.py
@@ -1198,16 +1198,16 @@ active: %.8X' % ((tev.color_op, tev.alpha_op, tev.color_bias, tev.alpha_bias,\
         mult.operation = 'MULTIPLY'
         links.new(hsv.outputs[2], mult.inputs[0])
         links.new(shiny.outputs[0], mult.inputs[1])
-        links.new(mult.outputs[0], shader.inputs[5])
+        links.new(mult.outputs[0], shader.inputs["Specular"])
     else:
-        shader.inputs[5].default_value = 0
+        shader.inputs["Specular"].default_value = 0
     #specular tint
-    shader.inputs[6].default_value = .5
+    shader.inputs["Specular Tint"].default_value = .5
     #roughness
-    shader.inputs[7].default_value = .5
+    shader.inputs["Roughness"].default_value = .5
 
     #diffuse color
-    links.new(last_color, shader.inputs[0])
+    links.new(last_color, shader.inputs["Base Color"])
 
     #alpha
     if transparent_shader:
@@ -1218,14 +1218,14 @@ active: %.8X' % ((tev.color_op, tev.alpha_op, tev.color_bias, tev.alpha_bias,\
         #links.new(last_alpha, alpha_factor.inputs[0])
         #last_alpha = alpha_factor.outputs[0]
         #
-        links.new(last_alpha, shader.inputs[21])
+        links.new(last_alpha, shader.inputs["Alpha"])
 
     #normal
     if last_bump:
         bump = nodes.new('ShaderNodeBump')
         bump.inputs[1].default_value = 1
         links.new(last_bump, bump.inputs[2])
-        links.new(bump.outputs[0], shader.inputs[22])
+        links.new(bump.outputs[0], shader.inputs["Normal"])
 
     #Add Additive or multiplicative alpha blending, since these don't have explicit options in 2.81 anymore
     if (alt_blend_mode == 'ADD'):


### PR DESCRIPTION
Moved the export button where it should be to avoid confusion.

Some inputs in the main shader were mixed up because of changes since Blender 2.83 and it made values and links not go to the right places. I discovered that you can use the English name to get the corresponding input. We should do that for the "Principled BSDF" node since it has more than 20 inputs and usually changes between major Blender versions.